### PR TITLE
Fix break lines in remote pairing

### DIFF
--- a/remote-pairing.md
+++ b/remote-pairing.md
@@ -12,16 +12,7 @@ In general, remote pairing is no different from collocated pairing except for th
 * Try to minimise the amount of environmental noise around you. Where possible, work in a quiet room.
 * Don’t forget there are whiteboard facilities on Zoom. This can be useful in explaining ideas.
 * When using remote screen control, latency is important!
-* Use a keystroke visualiser! Especially when you're demonstrating complicated keyboard shortcuts. Just be careful not
-
-  to expose any sensitive data such as user password from login form, etc. All major operating systems are shipping with
-
-  built-in keyboard viewer solutions out of the box. However, in our experience, specialised tools like, for example,
-
-  KeyCastr work better in a remote pairing environment as they provide a more focused view by displaying only one single
-
-  keystroke at a time.
-
+* Use a keystroke visualiser! Especially when you're demonstrating complicated keyboard shortcuts. Just be careful not to expose any sensitive data such as user password from login form, etc. All major operating systems are shipping with built-in keyboard viewer solutions out of the box. However, in our experience, specialised tools like, for example, KeyCastr work better in a remote pairing environment as they provide a more focused view by displaying only one single keystroke at a time.
   * [KeyCastr](https://github.com/keycastr/keycastr) for macOS
   * [Carnac](https://github.com/Code52/carnac) for Windows
   * Built-in [Keyboard Viewer](https://support.apple.com/en-gb/guide/mac-help/mchlp1015/mac) for macOS


### PR DESCRIPTION
I've removed some unnecessary break lines in the remote pairing file that were making the text in the playbook to read weird (https://remote-working.playbook.ee/remote-pairing)